### PR TITLE
refactor: use CARGO_PKG_VERSION for dynamic versioning

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,7 @@ impl Cli {
     fn build_cli(&self) -> Command {
         Command::new("rsp")
             .about("Raw String Peeler - Convert escaped strings in YAML to readable format")
-            .version("0.1.0")
+            .version(env!("CARGO_PKG_VERSION"))
             .subcommand(
                 Command::new("peel")
                     .about("Peel raw strings from YAML files")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -25,7 +25,7 @@ fn test_cli_version_command() {
         .expect("Failed to execute command");
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("rsp 0.1.0"));
+    assert!(stdout.contains(&format!("rsp {}", env!("CARGO_PKG_VERSION"))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace hardcoded version strings with `env\!("CARGO_PKG_VERSION")` macro
- Update CLI version display to read from Cargo.toml automatically
- Fix test to use dynamic version checking instead of hardcoded assertions

## Test plan
- [x] Verify `rsp --version` shows correct version from Cargo.toml
- [x] Run all tests to ensure version test works with dynamic checking
- [x] Build project successfully

🤖 Generated with [Claude Code](https://claude.ai/code)