### PR TITLE
Change crate name due to conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rsp"
+name = "rsp-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,9 @@ serde_yaml = "0.9"
 anyhow = "1.0"
 thiserror = "1.0"
 
+[[bin]]
+name = "rsp"
+path = "src/main.rs"
+
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rsp"
+name = "rsp-cli"
 version = "0.1.0"
 edition = "2024"
 authors = ["pomcho555 <pomcho555@users.noreply.github.com>"]

--- a/tests/edge_cases_tests.rs
+++ b/tests/edge_cases_tests.rs
@@ -1,4 +1,4 @@
-use rsp::peeler::Peeler;
+use rsp_cli::peeler::Peeler;
 use serde_yaml::Value;
 use std::io::Write;
 use tempfile::NamedTempFile;

--- a/tests/peeler_tests.rs
+++ b/tests/peeler_tests.rs
@@ -1,5 +1,5 @@
-use rsp::error::RspError;
-use rsp::peeler::Peeler;
+use rsp_cli::error::RspError;
+use rsp_cli::peeler::Peeler;
 use serde_yaml::Value;
 use std::fs;
 use tempfile::NamedTempFile;


### PR DESCRIPTION
The name 'rsp' is already used from another crate: https://crates.io/crates/rsp