### PR TITLE
Bug:update create keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["pomcho555 <pomcho555@users.noreply.github.com>"]
 repository = "https://github.com/pomcho555/rsp"
 readme = "README.md"
 license = "MIT"
-keywords = ["cli","escaped strings","converter","formatter"]
+keywords = ["cli","tool","converter","formatter"]
 description = """
 A Rust CLI tool that converts escaped strings embedded in YAML ConfigMaps into properly formatted multi-line strings.
 """


### PR DESCRIPTION
```sh
cargo publish
...
  the remote server responded with an error (status 400 Bad Request): "escaped strings" is an invalid keyword
```