### PR TITLE
Add badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # RSP (Raw String Peeler)
 
+[![Build Status](https://github.com/pomcho555/rsp/workflows/CI/badge.svg)](https://github.com/pomcho555/rsp/actions)
+[![Crates.io](https://img.shields.io/crates/v/rsp-cli.svg)](https://crates.io/crates/rsp-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A Rust CLI tool that converts escaped strings embedded in YAML ConfigMaps into properly formatted multi-line strings using YAML's pipe (`|`) syntax.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
## Summary
- Add build status badge for GitHub Actions CI workflow
- Add crates.io version badge for the rsp-cli package  
- Add MIT license badge for clear license information

## Test plan
- [x] Verify badges display correctly in README
- [x] Confirm badge URLs are correct for the repository
- [x] Test that badges link to appropriate pages

🤖 Generated with [Claude Code](https://claude.ai/code)