### PR TITLE
Add cargo install rsp-cli installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Rust CLI tool that converts escaped strings embedded in YAML ConfigMaps into p
 ## Table of Contents
 
 - [Installation](#installation)
+  - [From Crates.io](#from-cratesio)
   - [From Source](#from-source)
   - [Prerequisites](#prerequisites)
 - [Get Started](#get-started)
@@ -26,6 +27,14 @@ A Rust CLI tool that converts escaped strings embedded in YAML ConfigMaps into p
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
+
+### From Crates.io
+
+Install directly from crates.io using cargo:
+
+```bash
+cargo install rsp-cli
+```
 
 ### From Source
 


### PR DESCRIPTION
## Summary
- Added new installation section for installing from crates.io using `cargo install rsp-cli`
- Updated table of contents to include the new installation method
- Provides an easier installation option for users who don't need to build from source

## Test plan
- [x] Verify README.md formatting is correct
- [x] Confirm table of contents links work properly
- [x] Test the actual `cargo install rsp-cli` command works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)